### PR TITLE
Dicing bug fixes

### DIFF
--- a/A Taste of Culture/Assets/Scenes/Level 1/Chopping.unity
+++ b/A Taste of Culture/Assets/Scenes/Level 1/Chopping.unity
@@ -343,9 +343,9 @@ MonoBehaviour:
   budgeDuration: 0.1
   rotateXPosition: 2.92
   finalXPosition: 2.92
-  rotatedPosition: {x: 0, y: 0}
+  rotatedPosition: {x: -1.08, y: -0.37}
   choppedPrefab: {fileID: 2884203642612794587, guid: b00864d44c6c81341bf89c968ba42334, type: 3}
-  choppedPrefabPosition: {x: 0, y: 0}
+  choppedPrefabPosition: {x: -0.3, y: 0}
   choppedPrefabRotation: {x: 0, y: 0, z: 0}
   spriteMask: {fileID: 1490022700101722497, guid: 37977ce5956a4924791382d669c85cf7, type: 3}
   spriteMaskPosition: {x: 4.35, y: 0}
@@ -915,6 +915,10 @@ PrefabInstance:
     - target: {fileID: 1176281770708253665, guid: 1816e3dc5510a624da1e6acb09f1e4c8, type: 3}
       propertyPath: m_Name
       value: GIF Manager
+      objectReference: {fileID: 0}
+    - target: {fileID: 1176281770708253665, guid: 1816e3dc5510a624da1e6acb09f1e4c8, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1176281770708253670, guid: 1816e3dc5510a624da1e6acb09f1e4c8, type: 3}
       propertyPath: sceneManager
@@ -1931,9 +1935,9 @@ MonoBehaviour:
   budgeDuration: 0.125
   rotateXPosition: 3.15
   finalXPosition: 2.75
-  rotatedPosition: {x: 0, y: 0}
+  rotatedPosition: {x: -1.3, y: -0.3}
   choppedPrefab: {fileID: 8994391589829546340, guid: ffc139fea8cbe7041a182ceccd136a72, type: 3}
-  choppedPrefabPosition: {x: 0, y: 0}
+  choppedPrefabPosition: {x: -1.01, y: 0}
   choppedPrefabRotation: {x: 0, y: 0, z: 0}
   spriteMask: {fileID: 1490022700101722497, guid: 37977ce5956a4924791382d669c85cf7, type: 3}
   spriteMaskPosition: {x: 4.35, y: 0}

--- a/A Taste of Culture/Assets/Scenes/Level 2/Chopping.unity
+++ b/A Taste of Culture/Assets/Scenes/Level 2/Chopping.unity
@@ -1211,7 +1211,7 @@ MonoBehaviour:
   budgeDuration: 0.1
   rotateXPosition: 2.3
   finalXPosition: 0.8
-  rotatedPosition: {x: -0.1, y: 0}
+  rotatedPosition: {x: -0.28, y: 0}
   choppedPrefab: {fileID: 2884203642612794587, guid: ed30c487dd27179419ccb5614000cb78, type: 3}
   choppedPrefabPosition: {x: 0, y: -0.6}
   choppedPrefabRotation: {x: 0, y: 0, z: 90}
@@ -1727,7 +1727,7 @@ MonoBehaviour:
   budgeDuration: 0.1
   rotateXPosition: 2.3
   finalXPosition: 0.8
-  rotatedPosition: {x: -0.1, y: 0}
+  rotatedPosition: {x: -0.28, y: 0}
   choppedPrefab: {fileID: 2884203642612794587, guid: ed30c487dd27179419ccb5614000cb78, type: 3}
   choppedPrefabPosition: {x: 0, y: -0.6}
   choppedPrefabRotation: {x: 0, y: 0, z: 90}
@@ -2312,7 +2312,7 @@ MonoBehaviour:
   budgeDuration: 0.1
   rotateXPosition: 2.3
   finalXPosition: 0.8
-  rotatedPosition: {x: -0.1, y: 0}
+  rotatedPosition: {x: -0.28, y: 0}
   choppedPrefab: {fileID: 2884203642612794587, guid: ed30c487dd27179419ccb5614000cb78, type: 3}
   choppedPrefabPosition: {x: 0, y: -0.6}
   choppedPrefabRotation: {x: 0, y: 0, z: 270}
@@ -3711,7 +3711,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6075877295949646230, guid: c039b97f54a8b864b94250f0b3620a11, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.18
+      value: -0.24
       objectReference: {fileID: 0}
     - target: {fileID: 6075877295949646230, guid: c039b97f54a8b864b94250f0b3620a11, type: 3}
       propertyPath: m_LocalPosition.y
@@ -3787,7 +3787,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9007410564129555532, guid: c039b97f54a8b864b94250f0b3620a11, type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c039b97f54a8b864b94250f0b3620a11, type: 3}
@@ -4079,7 +4079,7 @@ MonoBehaviour:
   budgeDuration: 0.1
   rotateXPosition: 2.3
   finalXPosition: 0.8
-  rotatedPosition: {x: 0.02, y: 0}
+  rotatedPosition: {x: -0.03, y: 0}
   choppedPrefab: {fileID: 2884203642612794587, guid: ed30c487dd27179419ccb5614000cb78, type: 3}
   choppedPrefabPosition: {x: 0, y: -0.35}
   choppedPrefabRotation: {x: 0, y: 0, z: 90}
@@ -4161,7 +4161,7 @@ MonoBehaviour:
   budgeDuration: 0.1
   rotateXPosition: 2.43
   finalXPosition: 2.57
-  rotatedPosition: {x: -0.94, y: -0.58}
+  rotatedPosition: {x: -1.01, y: -0.58}
   choppedPrefab: {fileID: 2884203642612794587, guid: 097e797f6cc249c4e8854b543c98cc8b, type: 3}
   choppedPrefabPosition: {x: -0.45, y: -0.29}
   choppedPrefabRotation: {x: 0, y: 0, z: 0}

--- a/A Taste of Culture/Assets/Scripts/ChoppingKnife.cs
+++ b/A Taste of Culture/Assets/Scripts/ChoppingKnife.cs
@@ -16,6 +16,8 @@ public class ChoppingKnife : MonoBehaviour
     private bool canChop = true;
     public bool CanChop { set { canChop = value; } }
 
+    private bool madeFirstCut = false;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -47,6 +49,14 @@ public class ChoppingKnife : MonoBehaviour
 
         foreach(RaycastHit2D hitObject in hitObjects)
         {
+            // Check if a cut mask should be instantiated (avoids having serval cut masks on the same "cut")
+            if(!madeFirstCut) { madeFirstCut = true; }
+            else 
+            {
+                IngredientMover ingredientMover = hitObject.transform.parent.gameObject.GetComponent<IngredientMover>();
+                if(ingredientMover.AllowMovement) { continue; }
+            }
+            
             objectsToCut.Add(hitObject.transform.gameObject);
         }    
 

--- a/A Taste of Culture/Assets/Scripts/IngredientMover.cs
+++ b/A Taste of Culture/Assets/Scripts/IngredientMover.cs
@@ -30,7 +30,7 @@ public class IngredientMover : MonoBehaviour
 
     // Allow player to move ingredient.
     private bool allowMovement = false;
-    public bool AllowMovement { set { allowMovement = value; } }
+    public bool AllowMovement { set { allowMovement = value; } get { return allowMovement; } }
 
     // Allow player to rotate ingredient.
     private bool allowRotation = false;


### PR DESCRIPTION
Fixed the bug where chopped assets could be seen right after the first chop.

Also fixed the issue of multiple cut masks being instantiated for the same cut if the player continuously chops without moving the ingredient.